### PR TITLE
removes the additional grid/tile cell styling

### DIFF
--- a/public/js/tetris.js
+++ b/public/js/tetris.js
@@ -27,7 +27,6 @@ function drawSquare(x, y) {
   ctx.strokeStyle = '#555'
   ctx.strokeRect(x * tilesZ, y * tilesZ, tilesZ, tilesZ)
   ctx.strokeStyle = '#888'
-    //ctx.strokeRect(x * tilesZ + 3 * tilesZ / 8, y * tilesZ + 3 * tilesZ / 8, tilesZ / 4, tilesZ / 4)
   ctx.strokeStyle = sStyle
 }
 


### PR DESCRIPTION
this line of code would put additional squares inside the game pieces and the game playing area/grid. Removing this line of code entirely as upon further review, sometimes this additional styling actually affects the game over check and would create a "game over" infinite loop. The game still plays in the same way except now the pieces and each cell on the grid do not have little extra squares inside of them. 